### PR TITLE
Use listening IP parameter for an app view.

### DIFF
--- a/apps/manager/source/manager.cpp
+++ b/apps/manager/source/manager.cpp
@@ -1246,6 +1246,7 @@ uint16_t Manager::CreateApp(
 			error = "Invalid IP address: " + *ipStr;
 			return 0;
 		}
+		ip = ntohl(ip); //* Convert to LE
 	}
 
 	uint16_t port{ 0 };
@@ -1271,26 +1272,6 @@ uint16_t Manager::CreateApp(
 				return 0;
 			}
 		} while (true);
-	}
-
-	std::string parentPath;
-	if (const auto parentPathStr{ data.GetValue("parentPath") }; parentPathStr != nullptr && !parentPathStr->empty()) {
-		parentPath = *parentPathStr;
-	}
-	else {
-		if (std::string::size_type pos = appDataIt->second.bin.rfind("build/"); pos != std::string::npos) {
-			parentPath = std::string{ appDataIt->second.bin.begin(), appDataIt->second.bin.begin() + INT64(pos) };
-		}
-		else {
-			pos = appDataIt->second.bin.rfind("/");
-			if (pos != std::string::npos) {
-				parentPath = std::string{ appDataIt->second.bin.begin(), appDataIt->second.bin.begin() + INT64(pos) };
-			}
-			else {
-				error = "Invalid bin path in http request: " + appDataIt->second.bin;
-				return 0;
-			}
-		}
 	}
 
 	short logLevel{ static_cast<short>(MSAPI::Log::Level::WARNING) };
@@ -1337,8 +1318,8 @@ uint16_t Manager::CreateApp(
 	}
 
 	MSAPI::Json parameters{ "{\"name\":\"" + name + "\",\"ip\":\"" + _S(ip) + "\",\"port\":\"" + _S(port)
-		+ "\",\"managerPort\":\"" + _S(GetListenedPort()) + "\"	,\"parentPath\":\"" + parentPath + "\",\"logLevel\":\""
-		+ _S(logLevel) + "\",\"logInConsole\":\"" + _S(logInConsole) + "\",\"logInFile\":\"" + _S(logInFile)
+		+ "\",\"managerPort\":\"" + _S(GetListenedPort()) + "\",\"logLevel\":\"" + _S(logLevel)
+		+ "\",\"logInConsole\":\"" + _S(logInConsole) + "\",\"logInFile\":\"" + _S(logInFile)
 		+ "\",\"separateDaysLogging\":\"" + _S(separateDaysLogging) + "\"}" };
 
 	if (!parameters.Valid()) {

--- a/apps/manager/web/js/application.js
+++ b/apps/manager/web/js/application.js
@@ -610,7 +610,13 @@ class Application {
 			const parametersToPort = Application.#privateFields.m_parametersToPort.get(parameters.port);
 
 			// Create an iframe to display the app at the given URL and port
-			const url = parameters.url || `http://127.0.0.1:${parametersToPort[parameters.viewPortParameter]}/`;
+			const listeningIp = parametersToPort && parametersToPort[1000008] ? parametersToPort[1000008] : null;
+			if (!listeningIp) {
+				console.error("Parameter 1000008 (Listening IP) is not available for app on port", parameters.port);
+				return false;
+			}
+
+			const url = parameters.url || `http://${listeningIp}:${parametersToPort[parameters.viewPortParameter]}/`;
 			const iframe = document.createElement("iframe");
 			iframe.src = url;
 			iframe.style.width = "100%";
@@ -1706,7 +1712,6 @@ Application.AddViewTemplate("NewApp", `<div class="customView">
 			<div class="item"><input name="name" type="text" placeholder="Name"/></div>
 			<div class="item"><input value="127.0.0.1" name="ip" type="text" placeholder="Listening IP" canBeEmpty="false" /></div>
             <div class="item"><input name="port" type="number" placeholder="Listening Port" /></div>
-			<div class="item"><input value="../logs/"name="parentPath" type="text" placeholder="Parent directory for logging" /></div>
             <div class="item">
 				<label>
 					<input name="logInConsole" type="checkbox" />

--- a/apps/manager/web/js/helper.js
+++ b/apps/manager/web/js/helper.js
@@ -182,7 +182,8 @@ class Helper {
 
 	static IsFloat(num)
 	{
-		return (typeof num == "string" && num.includes('.')) || (Number(num) === num && num % 1 !== 0);
+		return (typeof num == "string" && num.includes('.') && !isNaN(Number(num)))
+			|| (Number(num) === num && num % 1 !== 0);
 	}
 
 	/**************************

--- a/apps/manager/web/js/iframeBridge.js
+++ b/apps/manager/web/js/iframeBridge.js
@@ -1,0 +1,37 @@
+/**************************
+ * This file is part of MSAPI.
+ * License: see LICENSE.md
+ * Contributor terms: see CONTRIBUTING.md
+ *
+ * This software is licensed under the Polyform Noncommercial License 1.0.0.
+ * You may use, copy, modify, and distribute it for noncommercial purposes only.
+ *
+ * For commercial use, please contact: maks.angels@mail.ru
+ *
+ * Required Notice: MSAPI, copyright © 2021–2025 Maksim Andreevich Leonov, maks.angels@mail.ru
+ *
+ * @brief Bridge script for iframe communication with MSAPI Manager.
+ *
+ * This script should be included in app views that are displayed in iframes within the MSAPI Manager.
+ *
+ * @usage Include this script in your app's HTML:
+ * <script src="/iframeBridge.js"></script>
+ */
+(function() {
+'use strict';
+
+// Listen for initialization message from parent window
+window.addEventListener("message", (event) => {
+	if (event.data && event.data.type === "init") {
+		window.parentOrigin = event.data.origin;
+		window.uid = event.data.uid;
+	}
+});
+
+// Forward click events to parent window
+window.addEventListener('click', function(event) {
+	if (window.parent && window.uid && window.parentOrigin) {
+		window.parent.postMessage({ type : 'iframeClick', uid : window.uid }, window.parentOrigin);
+	}
+});
+})();

--- a/library/source/server/application.h
+++ b/library/source/server/application.h
@@ -670,7 +670,7 @@ protected:
 	 *		Recv buffer size limit(1000005) : 10485760
 	 *		Server state(1000006) const : Running
 	 *		Max connections(1000007) const : 4096
-	 *		Listening IP(1000008) const : 0
+	 *		Listening IP(1000008) const : 127.0.0.1
 	 *		Listening port(1000009) const : 60328
 	 *		Name(2000001) const : Distributor
 	 *		Application state(2000002) const : Paused
@@ -851,8 +851,6 @@ protected:
  * @param ip (out) IP address of application [std::string]. INADDR_LOOPBACK by default.
  * @param port (out) Port of application [unsigned short]. Random from 3000 by default. Can't be equal to zero.
  * @param managerPort (out) Port of manager [unsigned short]. Can't be equal to zero.
- * @param parentPath (internal) Parent directory for logger, root of build directory or executable directory by default
- * (512 bytes are reserved).
  * @param logLevel (internal) Level of logging, WARNING by default.
  * @param logInConsole (internal) Enable logging in console, false by default.
  * @param logInFile (internal) Enable logging in file, false by default.
@@ -953,32 +951,15 @@ protected:
 		return 1;                                                                                                      \
 	}                                                                                                                  \
                                                                                                                        \
-	if (const auto* parentPath{ parameters.GetValue("parentPath") }; parentPath != nullptr) {                          \
-		if (const auto* value{ std::get_if<std::string>(&parentPath->GetValue()) }; value != nullptr) {                \
-			if (!value->empty()) {                                                                                     \
-				MSAPI::logger.SetParentPath(*value);                                                                   \
-			}                                                                                                          \
-			else {                                                                                                     \
-				goto setDefaultParentPath;                                                                             \
-			}                                                                                                          \
-		}                                                                                                              \
-		else {                                                                                                         \
-			std::cerr << "Invalid type of parent path in parameters, string is expected." << std::endl;                \
-			return 1;                                                                                                  \
-		}                                                                                                              \
+	std::string executablePath;                                                                                        \
+	executablePath.resize(512);                                                                                        \
+	MSAPI::Helper::GetExecutableDir(executablePath);                                                                   \
+	if (executablePath.empty()) {                                                                                      \
+		std::cerr << "Cannot get executable path." << std::endl;                                                       \
+		return 1;                                                                                                      \
 	}                                                                                                                  \
-	else {                                                                                                             \
-	setDefaultParentPath:                                                                                              \
-		std::string executablePath;                                                                                    \
-		executablePath.resize(512);                                                                                    \
-		MSAPI::Helper::GetExecutableDir(executablePath);                                                               \
-		if (executablePath.empty()) {                                                                                  \
-			std::cerr << "Cannot get executable path." << std::endl;                                                   \
-			return 1;                                                                                                  \
-		}                                                                                                              \
                                                                                                                        \
-		MSAPI::logger.SetParentPath(executablePath + "../");                                                           \
-	}                                                                                                                  \
+	MSAPI::logger.SetParentPath(executablePath + "../");                                                               \
                                                                                                                        \
 	if (const auto* logLevelStr{ parameters.GetValue("logLevel") }; logLevelStr != nullptr) {                          \
 		if (const auto* value{ std::get_if<std::string>(&logLevelStr->GetValue()) }; value != nullptr) {               \


### PR DESCRIPTION
Provide IP in LE to avoid double transformation.
Always use default path for logging.
Fix false-positive result of helper JS IsFloat function.